### PR TITLE
fixing (import Mapping from collections), issue #91639

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -37,6 +37,7 @@ from operator import eq as _eq
 from operator import itemgetter as _itemgetter
 from reprlib import recursive_repr as _recursive_repr
 from _weakref import proxy as _proxy
+from collections.abc import Mapping
 
 try:
     from _collections import deque


### PR DESCRIPTION
Concerning python 3.10, the following error occurs for scripts trying to import `Mapping` from `collections`

### Error:
`
ImportError: cannot import name 'Mapping' from 'collections' (/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/collections/__init__.py
`
### Proposed Solution:
add the following line to the `collections/__init__.py`
**Line :** `from collections.abc import Mapping`

### Reason:
Python scripts using the `collections` library form older versions would face problems when updating to **python 3.10**

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
